### PR TITLE
Fix image centering on safari

### DIFF
--- a/assets/css/section.scss
+++ b/assets/css/section.scss
@@ -69,12 +69,18 @@
 
 }
 
-/* Shift section image down by half to be in the middle of the text column */
-.section-2col .section-cover {
-    /* Vertical Align */
-    top: 50%;
-    transform: translateY(-50%);
+// Vertically align image with content
+.section-2col-img-container {
+    display: flex;
+    align-items: center;
 
+    // turn it off on tablet width so it centers horizontally
+    @media ($tablet) {
+        display: inherit;
+    }
+}
+
+.section-2col .section-cover {
     @media ($tablet) {
         top: auto;
         transform: none;

--- a/layouts/partials/section.html
+++ b/layouts/partials/section.html
@@ -2,7 +2,7 @@
 
 {{ if in "2col-left 2col-right" .Params.Layout }}
   <div class="section-2col section-{{ .Params.Layout | plainify }}">
-    <div>
+    <div class="section-2col-img-container">
       {{ .Scratch.Set "cover_type" "section" }}
       {{ partial "cover.html" . }}
     </div>


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix image centering issue on Safari by adjusting CSS for vertical alignment.